### PR TITLE
Changes from background agent bc-1b1630e4-e42c-4cde-a3ea-72d096cb2b0e

### DIFF
--- a/Tesis_Back/ia/services.py
+++ b/Tesis_Back/ia/services.py
@@ -247,6 +247,15 @@ def build_verifier_prompt(summary_markdown: str, db_json: dict) -> str:
 
 # === 3) Orquestador ===
 def run_summary_and_verification(topic: str, filters: dict):
+    """
+    Orquesta el resumen general. Si recibe un causa_id en filters,
+    deriva al flujo específico de causa para evitar KPIs globales.
+    """
+    # Si piden explícitamente una causa, usar el flujo enfocado por causa
+    causa_id = (filters or {}).get("causa_id")
+    if causa_id:
+        return run_case_summary_and_verification(int(causa_id))
+
     db_json = build_db_context(topic, filters)
 
     # --- SUMMARIZER (GPT “grande”: gpt-4o recomendado) ---


### PR DESCRIPTION
Delegate single-cause summary generation to avoid global KPIs when `causa_id` is provided in filters.

Previously, `run_summary_and_verification` would always build a global context, even if a `causa_id` was specified, leading to summaries that included overall metrics like `total_causas`. This change ensures that requests for a specific `causa_id` are handled by the dedicated single-cause summarization flow, providing focused data.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b1630e4-e42c-4cde-a3ea-72d096cb2b0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1b1630e4-e42c-4cde-a3ea-72d096cb2b0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

