### PR TITLE
Fix summary persistence bug

### DIFF
--- a/Tesis_Back/ia/views.py
+++ b/Tesis_Back/ia/views.py
@@ -120,7 +120,7 @@ class SummaryRunViewSet(viewsets.ModelViewSet):
         causa = get_object_or_404(Causa.objects.filter(creado_por=user), pk=int(causa_id))
         run = (SummaryRun.objects
                .filter(causa=causa, created_by=user)
-               .order_by("-created_at")
+               .order_by("-updated_at", "-created_at")
                .first())
         if not run:
             return Response({"detail": "No existe un resumen para esta causa."},
@@ -227,7 +227,7 @@ class SummaryRunViewSet(viewsets.ModelViewSet):
                 run = (SummaryRun.objects
                        .select_for_update()
                        .filter(causa=causa, created_by=user)
-                       .order_by("-created_at")
+                       .order_by("-updated_at", "-created_at")
                        .first())
                 if not run:
                     return Response(
@@ -365,6 +365,7 @@ class CaseSummaryView(GenericAPIView):
 
         run = SummaryRun.objects.create(
             topic=f"Resumen de causa #{causa.id}",
+            causa=causa,
             filters={"causa_id": causa.id},
             db_snapshot=ctx,
             prompt="(generado internamente en ia.services)",


### PR DESCRIPTION
Link `SummaryRun` to its `causa` and retrieve the most recently updated summary to fix persistence and retrieval issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-69814ae5-7f55-4917-96bd-085459a527fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-69814ae5-7f55-4917-96bd-085459a527fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

